### PR TITLE
fixed cms page link

### DIFF
--- a/app/code/community/Valdecode/CookieLaw/Helper/Data.php
+++ b/app/code/community/Valdecode/CookieLaw/Helper/Data.php
@@ -60,7 +60,7 @@ class Valdecode_CookieLaw_Helper_Data extends Mage_Core_Helper_Abstract
             $pageId = substr($pageId, 0, $delimeterPosition);
         }
          
-        return Mage::getUrl($pageId);
+        return Mage::helper('cms/page')->getPageUrl($pageId);
     }
 
     public function getShow()


### PR DESCRIPTION
Currently, the helper returns a weird URL, which does not work like `https://www.domain.tld/1` if `1` is the page ID. This PR fixes this issue.

By the way, what is the purpose of the delimiter position and substr stuff?